### PR TITLE
fix: add naming strategy to binding

### DIFF
--- a/frontend/packages/topology/src/operators/actions/serviceBindings.ts
+++ b/frontend/packages/topology/src/operators/actions/serviceBindings.ts
@@ -34,6 +34,8 @@ export const createServiceBinding = (
       namespace,
     },
     spec: {
+      bindAsFiles: true,
+      namingStrategy: 'none',
       application: {
         name: sourceName,
         group: sourceGroup[0],


### PR DESCRIPTION
Workaround for temporary issue:
https://github.com/redhat-developer/service-binding-operator/issues/945

No merge needed.